### PR TITLE
Correct variable name used in imx93, imx6ull, and imx8mm configs, properly create partition table if required

### DIFF
--- a/boards/cfg_imx6ull_base.cfg
+++ b/boards/cfg_imx6ull_base.cfg
@@ -20,7 +20,7 @@ IMAGE_PT_TBL_LENGTH=512
 # Format: [PARTITION_NAME:<OFFSET_START>:<OFFSET_END>:<Filesystem Type>]
 # Numbers and fs type in this struct will be passed to command directly.
 # sudo parted <PARTITION_NAME> unit MiB mkpart primary <Filesystem Type> <OFFSET_START> <OFFSET_END>
-IMAGE_PT_TABLE_STRUCT="
+IMAGE_PT_TBL_STRUCT="
 1:SLOTA_BOOT_PT:100:220:fat32
 2:SLOTA_ROOTFS:220:3220:ext4
 3:SLOTB_BOOT_PT:3220:3340:fat32

--- a/boards/cfg_imx8mm_base.cfg
+++ b/boards/cfg_imx8mm_base.cfg
@@ -20,7 +20,7 @@ IMAGE_PT_TBL_LENGTH=512
 # Format: [PARTITION_NAME:<OFFSET_START>:<OFFSET_END>:<Filesystem Type>]
 # Numbers and fs type in this struct will be passed to command directly.
 # sudo parted <PARTITION_NAME> unit MiB mkpart primary <Filesystem Type> <OFFSET_START> <OFFSET_END>
-IMAGE_PT_TABLE_STRUCT="
+IMAGE_PT_TBL_STRUCT="
 1:SLOTA_BOOT_PT:100:220:fat32
 2:SLOTA_ROOTFS:220:3220:ext4
 3:SLOTB_BOOT_PT:3220:3340:fat32

--- a/boards/cfg_imx93_base.cfg
+++ b/boards/cfg_imx93_base.cfg
@@ -20,7 +20,7 @@ IMAGE_PT_TBL_LENGTH=512
 # Format: [PARTITION_NAME:<OFFSET_START>:<OFFSET_END>:<Filesystem Type>]
 # Numbers and fs type in this struct will be passed to command directly.
 # sudo parted <PARTITION_NAME> unit MiB mkpart primary <Filesystem Type> <OFFSET_START> <OFFSET_END>
-IMAGE_PT_TABLE_STRUCT="
+IMAGE_PT_TBL_STRUCT="
 1:SLOTA_BOOT_PT:100:220:fat32
 2:SLOTA_ROOTFS:220:3220:ext4
 3:SLOTB_BOOT_PT:3220:3340:fat32

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -159,6 +159,10 @@ function generate_pt_tbl_dualslot()
 		exit -1
 	fi
 
+	if [ "$PT_FMT" == "MBR" ]; then
+		parted ${PT_DISKLABEL} mklabel msdos
+	fi
+
 	for each_item in $IMAGE_PT_TBL_STRUCT; do
 		local pt_index=$(echo $each_item | cut -d: -f1)
 		local pt_name=$(echo $each_item | cut -d: -f2)
@@ -167,7 +171,7 @@ function generate_pt_tbl_dualslot()
 		local pt_fs=$(echo $each_item | cut -d: -f5)
 		case $PT_FMT in
 			MBR)
-				sudo parted ${PT_DISKLABEL} unit MiB mkpart primary ${pt_fs} ${pt_start} ${pt_end}
+				parted ${PT_DISKLABEL} unit MiB mkpart primary ${pt_fs} ${pt_start} ${pt_end}
 				;;
 			GPT)
 				sudo sgdisk -a 8 -n ${pt_index}:${pt_start}:${pt_end} -t ${pt_index}:${pt_fs} -c ${pt_index}:${pt_name} -e ${PT_DISKLABEL}
@@ -185,7 +189,7 @@ function generate_pt_tbl_dualslot()
 
 	case $PT_FMT in
 		MBR)
-			sudo parted ${PT_DISKLABEL} unit MiB print
+			parted ${PT_DISKLABEL} unit MiB print
 			;;
 		GPT)
 			sudo sgdisk -p -e ${PT_DISKLABEL}


### PR DESCRIPTION
The board definitions in this repo do not work with imx93, imx6ull, or imx8mm as the variable in those board configs was defined as IMAGE_PT_TABLE_STRUCT, while utils.sh expects IMAGE_PT_TBL_STRUCT.

Additionally, attempting to use parted on the file created with "truncate -s" does not work as parted fails immediately because it does not recognize the disk label.  If the partition type is "MBR", parted is called to create a new msdos disk label before attempting to create any partitions.

I also do not believe that sudo is required to make these images, as the disk image being manipulated is owned by the user running the script.

This fixes some of the problems that I was having with #4, but I am still digging into this.  I'm not entirely sure what to do with the host tools being older than the tools built in Yocto other than creating the swupdate image within Yocto and only using this repo as a reference.